### PR TITLE
Serve Swagger-UI oauth2-redirect.html content in the default route

### DIFF
--- a/flask-openapi3-swagger/flask_openapi3_swagger/plugins.py
+++ b/flask-openapi3-swagger/flask_openapi3_swagger/plugins.py
@@ -36,7 +36,7 @@ class RegisterPlugin(BasePlugin):
             )
         )
         blueprint.add_url_rule(
-            rule=f"/{cls.name}/oauth2-redirect",
+            rule=f"/oauth2-redirect.html",
             endpoint="oauth2-redirect",
             view_func=lambda: render_template_string(
                 swagger_oauth2_redirect_html_string


### PR DESCRIPTION
This should make sure there is no need to override [oauth2RedirectUrl](https://github.com/swagger-api/swagger-ui/blob/HEAD/docs/usage/configuration.md#network) parameter as the default behavior will match Swagger-UI expected URL.